### PR TITLE
[TEST] cmake: introduce cmake support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,24 @@ jobs:
         if: always()
         with:
           report_paths: result.xml
+  build-with-cmake:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Install libraries
+        run: |
+          sudo apt update
+          sudo apt install cmake ninja-build clang
+
+      - name: Build
+        run: |
+          src_dir="${{ github.workspace }}"
+          build_dir="$src_dir/build"
+          cmake -S $src_dir -B $build_dir -G Ninja -DCMAKE_C_COMPILER=clang
+          ninja -C $build_dir
   lint-python-scripts:
     runs-on: ubuntu-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(yc-libvhost-server C)
+
+if(UNIX AND NOT APPLE)
+  set(LINUX TRUE)
+endif()
+
+if(NOT LINUX)
+  message(FATAL_ERROR "Unsupported platform")
+endif()
+
+set(LIBVHOST_LOG_VERBOSITY "LOG_INFO" CACHE STRING "Libvhost log verbosity")
+message("Compiler ${CMAKE_C_COMPILER}")
+message("Libvhost log verbosity: ${LIBVHOST_LOG_VERBOSITY}")
+
+add_library(vhost-server)
+add_compile_definitions(_GNU_SOURCE LOG_VERBOSITY=${LIBVHOST_LOG_VERBOSITY})
+target_compile_options(vhost-server PRIVATE
+  -Wall
+  -Werror
+  -Wextra
+  -Wno-unused-parameter
+  -g
+  -O2
+
+  # make these warnings non-fatal in gcc
+  $<$<C_COMPILER_ID:GNU>:
+    -Wno-error=unused-value
+    -Wno-error=unused-result
+    -Wno-error=strict-aliasing
+  >
+
+  # enable additional warnings to enforce coding standards
+  -Wmissing-prototypes
+  -Wmissing-declarations
+  $<$<C_COMPILER_ID:Clang>:
+    -Wmissing-variable-declarations
+    -Wzero-length-array
+  >
+  $<$<C_COMPILER_ID:GNU>:
+    -Wzero-length-bounds
+  >
+)
+target_include_directories(vhost-server PUBLIC
+  include
+)
+target_include_directories(vhost-server PRIVATE
+  ./
+)
+target_sources(vhost-server PRIVATE
+  blockdev.c
+  event.c
+  fs.c
+  logging.c
+  memlog.c
+  memmap.c
+  server.c
+  vdev.c
+  virtio/virt_queue.c
+  virtio/virtio_blk.c
+  virtio/virtio_fs.c
+)


### PR DESCRIPTION
Cmake is used by NBS releases, so allow building the library with it.

To build the library with cmake:
  cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=clang && ninja -C build